### PR TITLE
Announce SoCraTes BE 2026 (22-25 October)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
     <title>SoCraTes BE</title>
 
-    <meta name="description" content="SoCraTes BE 2025, The unconference for software crafters, by software crafters">
+    <meta name="description" content="SoCraTes BE 2026, The unconference for software crafters, by software crafters">
     <meta name="keywords" content="unconference, open space, belgium, unconference Belgium, socrates, socratesbe">
     <meta name="author" content="SoCraTesBE">
 
@@ -44,11 +44,9 @@
     <div class="hero-heading-top centered-block align-center">
         <h1 class="extra-heading">SoCraTes BE</h1>
         <h2 class="thin base-font">Unconference</h2>
-        <h4 class="base-font"><i class="fa-solid fa-calendar" ></i>&nbsp;&nbsp;09 - 12 October 2025</h4>
+        <h4 class="base-font"><i class="fa-solid fa-calendar" ></i>&nbsp;&nbsp;22 - 25 October 2026</h4>
         <h4 class="base-font location-in-header"><a href="#venue"><i class="fa-solid fa-location-dot"></i>&nbsp;&nbsp;Floreal La Roche-En-Ardenne</a></h4>
-        <h3 class="book-tickets-now"><a href="https://forms.gle/wdtJ7Em5PoNhXhjQ7" target="_blank"><strong
-                class="highlight heading">Book your tickets NOW!</strong></a></h3>
-        <div><Strong></Strong>Single room ticket 550€, Shared room ticket 500€ (tickets are all in, conference, stay, food and drinks)</Strong></div>
+        <h3 class="book-tickets-now"><strong class="highlight heading">Registration opening soon!</strong></h3>
         <h3 class="thin base-font">For software crafters</h3>
         <h3 class="thin base-font">By software crafters</h3>
     </div>
@@ -242,9 +240,9 @@
                     </div>
                     <div class="col-sm-7 align-left">
                         <h6>About the event</h6>
-                        <p>This year's SoCraTes unconference runs from Thursday 09 October to Sunday 12 October 2025 at  <i class="fa-solid fa-location-dot"></i><a href="https://www.florealgroup.be/nl/vakantiepark/floreal-la-roche-en-ardenne" target="_blank"> Floreal, La Roche-En-Ardenne</a>.</p>
+                        <p>This year's SoCraTes unconference runs from Thursday 22 October to Sunday 25 October 2026 at  <i class="fa-solid fa-location-dot"></i><a href="https://www.florealgroup.be/nl/vakantiepark/floreal-la-roche-en-ardenne" target="_blank"> Floreal, La Roche-En-Ardenne</a>.</p>
                         <br/>
-                        <p>We’ll kick off Thursday evening with dinner at 7 PM. After dinner, around 8.30 PM, we will officially open the fifth edition of
+                        <p>We’ll kick off Thursday evening with dinner at 7 PM. After dinner, around 8.30 PM, we will officially open the eighth edition of
                            SoCraTes BE with a warm up session to get all the brains fired up. When the warm up session is finished, the floor is yours to
                            continue the conversation, twist it around and branch it in every direction.
                         </p>
@@ -254,7 +252,7 @@
                            software.</p><br/>
                         <p>On Friday and Saturday evenings, attendees are encouraged to run social activities, from pair-programming to board games and
                            everything in between.</p><br/>
-                        <p>The conference is officially over on Sunday the 12th October after breakfast.</p>
+                        <p>The conference is officially over on Sunday the 25th October after breakfast.</p>
                         <br/>
                     </div>
                 </div>
@@ -262,12 +260,8 @@
                 <div id="horizontal_tab5" class="tab-pane fade">
                     <div class="col-sm-12 align-left">
                         <h3>Pricing</h3>
-                        <p>The price for attending the unconference 2024 is</p>
-                        <ul style="list-style-type: circle; margin-left: 40px;   padding-left: 40px;">
-                            <li><b>550 euro VAT incl for a single room</b></li>
-                            <li><b>500 euro VAT incl for a shared room</b></li>
-                        </ul>
-                        <p>This is an all-in price, including your hotel stay, meals, drinks during socials, and usage of all the facilities throughout the conference.</p>
+                        <p>The price for attending the unconference 2026 will be announced soon.</p>
+                        <p>This will be an all-in price, including your hotel stay, meals, drinks during socials, and usage of all the facilities throughout the conference.</p>
                         <br/>
                         <h6 class="heading-alt">Cancellation Policy</h6>
                         <p>Cancellation can be performed by us if we are informed within 14 days of your registration. The cancellation policy can be reviewed in more
@@ -298,9 +292,9 @@
                         </p>
                         <br/>
                         <h3>Book tickets</h3>
-                        <h6 class="heading-alt">Join SoCraTes 2025!</h6>
+                        <h6 class="heading-alt">Join SoCraTes 2026!</h6>
                         <p>
-                            Reserve your tickets today via <a href="https://forms.gle/wdtJ7Em5PoNhXhjQ7" target="_blank">this Google Form</a>!
+                            Registration will open soon. Stay tuned!
                         </p>
                     </div>
                 </div>
@@ -621,10 +615,10 @@
 
                 <!-- Navigation by day start -->
                 <ul class="nav nav-schedule">
-                    <li class="active"><a href="#schedule3_day1" data-toggle="tab">Thursday, October 09</a></li>
-                    <li><a href="#schedule3_day2" data-toggle="tab">Friday, October 10</a></li>
-                    <li><a href="#schedule3_day3" data-toggle="tab">Saturday, October 11</a></li>
-                    <li><a href="#schedule3_day4" data-toggle="tab">Sunday, October 12</a></li>
+                    <li class="active"><a href="#schedule3_day1" data-toggle="tab">Thursday, October 22</a></li>
+                    <li><a href="#schedule3_day2" data-toggle="tab">Friday, October 23</a></li>
+                    <li><a href="#schedule3_day3" data-toggle="tab">Saturday, October 24</a></li>
+                    <li><a href="#schedule3_day4" data-toggle="tab">Sunday, October 25</a></li>
                 </ul>
                 <!-- Navigation by day end -->
 
@@ -1523,7 +1517,7 @@
                             class="fa-brands fa-github"></span></a></li>
                 </ul>
 
-                <p class="text-alt"><small>All Rights Reserved © 2024</small></p>
+                <p class="text-alt"><small>All Rights Reserved © 2026</small></p>
             </div>
 
         </div>


### PR DESCRIPTION
Update all dates, edition number, and registration copy for the 2026 edition. Registration link and pricing to be filled in once available.